### PR TITLE
Multi-line comments etc.

### DIFF
--- a/CodeTree.go
+++ b/CodeTree.go
@@ -323,7 +323,6 @@ func FromFilelist(filelist []string) (*CodeTree, error) {
 		errsLock.Lock()
 		errs = append(errs, message)
 		errsLock.Unlock()
-		return
 	}
 
 	for i, filename := range filelist {

--- a/CodeTree.go
+++ b/CodeTree.go
@@ -46,6 +46,39 @@ func (tree *CodeTree) Close() {
 	pool.Put(tree)
 }
 
+// String returns a string describing this node which can be used in error messages.
+func (tree *CodeTree) String() string {
+	s := tree.GetFilename()
+	if s != "" {
+		s = fmt.Sprintf("in file %s ", s)
+	}
+	if tree.LineNumber != 0 {
+		s = fmt.Sprintf("%son line %d ", s, tree.LineNumber)
+	}
+	switch tree.Type {
+	case RootType:
+		s = fmt.Sprintf("%s[root]", s)
+	case LineType:
+		s = fmt.Sprintf("%s[line]", s)
+	case CommentType:
+		s = fmt.Sprintf("%s[comment]", s)
+	}
+	if tree.Line != "" {
+		s = fmt.Sprintf("%s: %s", s, tree.Line)
+	}
+	return s
+}
+
+func (tree *CodeTree) GetFilename() string {
+	if tree.Filename != "" {
+		return tree.Filename
+	}
+	if tree.Root != nil {
+		return tree.Root.Filename
+	}
+	return ""
+}
+
 // New returns a tree structure if you feed it with indentation based source code.
 func New(src string) (*CodeTree, error) {
 	reader := strings.NewReader(src)

--- a/CodeTree.go
+++ b/CodeTree.go
@@ -1,7 +1,10 @@
 package codetree
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"sync"
 )
@@ -13,12 +16,22 @@ var pool = sync.Pool{
 	},
 }
 
+const (
+	RootType = iota
+	LineType
+	CommentType
+)
+
 // CodeTree ...
 type CodeTree struct {
-	Line     string
-	Children []*CodeTree
-	Parent   *CodeTree
-	Indent   int
+	Line       string
+	Children   []*CodeTree
+	Parent     *CodeTree
+	Root       *CodeTree
+	Indent     int
+	LineNumber int
+	Filename   string
+	Type       int
 }
 
 // Close sends the tree and all of its children back to the memory pool.
@@ -30,65 +43,99 @@ func (tree *CodeTree) Close() {
 	}
 
 	tree.Children = nil
+	tree.Parent = nil
+	tree.Root = nil
 	pool.Put(tree)
 }
 
-// New returns a tree structure if you feed it with indentantion based source code.
+// String returns a string describing this node which can be used in error messages.
+func (tree *CodeTree) String() string {
+	s := tree.GetFilename()
+	if s != "" {
+		s = fmt.Sprintf("in file %s ", s)
+	}
+	if tree.LineNumber != 0 {
+		s = fmt.Sprintf("%son line %d ", s, tree.LineNumber)
+	}
+	switch tree.Type {
+	case RootType:
+		s = fmt.Sprintf("%s[root]", s)
+	case LineType:
+		s = fmt.Sprintf("%s[line]", s)
+	case CommentType:
+		s = fmt.Sprintf("%s[comment]", s)
+	}
+	if tree.Line != "" {
+		s = fmt.Sprintf("%s: %s", s, tree.Line)
+	}
+	return s
+}
+
+func (tree *CodeTree) GetFilename() string {
+	if tree.Filename != "" {
+		return tree.Filename
+	}
+	if tree.Root != nil {
+		return tree.Root.Filename
+	}
+	return ""
+}
+
+// New returns a tree structure if you feed it with indentation based source code.
 func New(src string) (*CodeTree, error) {
+	reader := strings.NewReader(src)
+	return FromReader(reader)
+}
+
+const (
+	lineStartState = iota
+	lineState
+	commentStartState
+	commentLineState
+	multilineCommentState
+	multilineCommentEndState
+)
+
+// FromReader returns a CodeTree, taking an io.Reader as an argument instead of a string.
+// This approach is more idiomatic, versatile and efficient.
+// Uses a finite state machine type pattern to parse src in a single pass.
+func FromReader(src io.Reader) (*CodeTree, error) {
 	ast := pool.Get().(*CodeTree)
-	ast.Indent = -1
 	ast.Line = ""
-	ast.Parent = nil
+	ast.Root = ast
+	ast.Indent = -1
+	ast.LineNumber = 0
+	ast.Filename = ""
+	ast.Type = RootType
 
 	block := ast
 	lastNode := ast
-	lineStart := 0
 
-	for i := 0; i <= len(src); i++ {
-		if i != len(src) && src[i] != '\n' {
-			continue
-		}
+	var (
+		b      byte
+		tabs   int
+		spaces int
+		state  int
+		err    error
+	)
 
-		var line string
+	readBytes := 512
+	nodeType := LineType
+	lineNumber := 1
+	lastLineNumber := 1
+	line := make([]byte, 0, 128)
+	buf := make([]byte, readBytes)
 
-		if i > 0 && src[i-1] == '\r' {
-			// Windows line endings
-			line = src[lineStart : i-1]
-		} else {
-			// Unix line endings
-			line = src[lineStart:i]
-		}
-
-		lineStart = i + 1
+	addNode := func() error {
+		state = lineStartState
 
 		// Ignore empty lines
-		empty := true
-
-		for h := 0; h < len(line); h++ {
-			if line[h] != '\t' && line[h] != ' ' {
-				empty = false
-				break
-			}
-		}
-
-		if empty {
-			continue
+		if len(line) == 0 {
+			return nil
 		}
 
 		// Indentation
-		indent := 0
-
-		for indent < len(line) {
-			if line[indent] != '\t' {
-				break
-			}
-
-			indent++
-		}
-
-		if indent != 0 {
-			line = line[indent:]
-		}
+		indent := tabs + spaces/2
 
 		if indent == block.Indent+1 {
 			// OK
@@ -103,17 +150,205 @@ func New(src string) (*CodeTree, error) {
 				}
 			}
 		} else if indent > block.Indent+2 {
-			lineNumber := strings.Count(src[:i], "\n") + 1
-			return nil, fmt.Errorf("Invalid indentation on line %d: %s", lineNumber, line)
+			return fmt.Errorf("invalid indentation on line %d: %s", lineNumber, line)
 		}
 
 		node := pool.Get().(*CodeTree)
-		node.Line = line
+		node.Line = string(line)
 		node.Indent = indent
 		node.Parent = block
+		node.Root = ast
+		node.LineNumber = lastLineNumber
+		node.Type = nodeType
 		lastNode = node
 		block.Children = append(block.Children, node)
+
+		// Reset
+		tabs = 0
+		spaces = 0
+		line = line[:0]
+		nodeType = LineType
+		return nil
 	}
 
+	endLine := func() error {
+		if err = addNode(); err != nil {
+			return err
+		}
+		lastLineNumber = lineNumber
+		return nil
+	}
+
+	beginComment := func() error {
+		indent := 0
+		if len(line) > 0 {
+			indent = tabs + spaces/2 + 1
+		}
+		if err = addNode(); err != nil {
+			return err
+		}
+		tabs += indent
+		nodeType = CommentType
+		return nil
+	}
+
+	for {
+		br, _ := src.Read(buf)
+		for i := 0; i < br; i++ {
+			b = buf[i]
+
+			if b == '\r' {
+				continue
+			}
+
+			// Match states first, then tokens.
+			// More verbose but, with fewer possible states than possible tokens, optimal.
+			switch state {
+			case lineStartState:
+				switch b {
+				default:
+					state = lineState
+					line = append(line, b)
+				case '\t':
+					tabs++
+				case ' ':
+					spaces++
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				case '/':
+					state = commentStartState
+				}
+			case lineState:
+				switch b {
+				default:
+					line = append(line, b)
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				case '/':
+					state = commentStartState
+				}
+			case commentStartState:
+				switch b {
+				default:
+					state = lineState
+				case '/':
+					if err = beginComment(); err != nil {
+						return nil, err
+					}
+					state = commentLineState
+				case '*':
+					if err = beginComment(); err != nil {
+						return nil, err
+					}
+					state = multilineCommentState
+				}
+				line = append(line, '/', b)
+				if b == '\n' {
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				}
+			case commentLineState:
+				switch b {
+				default:
+					line = append(line, b)
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				}
+			case multilineCommentState:
+				switch b {
+				case '*':
+					state = multilineCommentEndState
+				case '\n':
+					lineNumber++
+				}
+				line = append(line, b)
+			case multilineCommentEndState:
+				switch b {
+				case '\n':
+					lineNumber++
+					fallthrough
+				default:
+					state = multilineCommentState
+					line = append(line, b)
+				case '/':
+					line = append(line, b)
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+		if br < readBytes {
+			break
+		}
+	}
+	lineNumber++
+	if err = endLine(); err != nil {
+		return nil, err
+	}
+	return ast, nil
+}
+
+// FromFilelist returns a CodeTree whose every child element is a CodeTree built from the contents of a single file as
+// enumerated in filelist. Each child CodeTree has its Filename element set to the corresponding element in filelist.
+// This structure is parsed properly by Scarlett.
+func FromFilelist(filelist []string) (*CodeTree, error) {
+	ast := pool.Get().(*CodeTree)
+	ast.Line = ""
+	ast.Children = make([]*CodeTree, len(filelist))
+	ast.Root = ast
+	ast.Indent = -1
+	ast.LineNumber = 0
+	ast.Filename = ""
+	ast.Type = RootType
+
+	var (
+		wg       sync.WaitGroup
+		errsLock sync.Mutex
+		errs     []string
+	)
+
+	recordError := func(message string) {
+		errsLock.Lock()
+		errs = append(errs, message)
+		errsLock.Unlock()
+		return
+	}
+
+	for i, filename := range filelist {
+		wg.Add(1)
+		go func(i int, filename string) {
+			file, err := os.Open(filename)
+			if err != nil {
+				recordError(fmt.Sprintf("error reading file:%s", err))
+				return
+			}
+			tree, err := FromReader(file)
+			file.Close()
+			if err != nil {
+				recordError(err.Error())
+				return
+			}
+			tree.Filename = filename
+			ast.Children[i] = tree
+			wg.Done()
+		}(i, filename)
+	}
+
+	wg.Wait()
+	if len(errs) != 0 {
+		return nil, errors.New(strings.Join(errs, "\n"))
+	}
 	return ast, nil
 }

--- a/CodeTree.go
+++ b/CodeTree.go
@@ -2,6 +2,7 @@ package codetree
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 )
@@ -15,10 +16,11 @@ var pool = sync.Pool{
 
 // CodeTree ...
 type CodeTree struct {
-	Line     string
-	Children []*CodeTree
-	Parent   *CodeTree
-	Indent   int
+	Line       string
+	Children   []*CodeTree
+	Parent     *CodeTree
+	Indent     int
+	LineNumber int
 }
 
 // Close sends the tree and all of its children back to the memory pool.
@@ -33,33 +35,67 @@ func (tree *CodeTree) Close() {
 	pool.Put(tree)
 }
 
-// New returns a tree structure if you feed it with indentantion based source code.
+// New returns a tree structure if you feed it with indentation based source code.
 func New(src string) (*CodeTree, error) {
 	ast := pool.Get().(*CodeTree)
 	ast.Indent = -1
 	ast.Line = ""
 	ast.Parent = nil
+	ast.LineNumber = 0
 
 	block := ast
 	lastNode := ast
 	lineStart := 0
+	numLines := 0
+	lineNumber := 1
 	src = strings.Replace(src, "\r\n", "\n", -1)
+	srcLen := len(src)
+	comSrcLen := srcLen - 2
 
-	for i := 0; i <= len(src); i++ {
-		if i != len(src) && src[i] != '\n' {
+	for i := 0; i <= srcLen; i++ {
+
+		line := ""
+		lineNumber += numLines
+
+		// Find multiline comments
+		comOpenEnd := i + 2
+		if i < comSrcLen && src[i:comOpenEnd] == "/*" {
+			comLen := strings.Index(src[comOpenEnd:], "*/")
+			if comLen == -1 {
+				i = srcLen - 1
+			} else {
+				i += comLen + 3
+			}
+			line = src[lineStart : i+1]
+			numLines = strings.Count(line, "\n")
+
+		} else if i != srcLen && src[i] != '\n' { // or skip forward until a full line is found
+			numLines = 0
 			continue
+
+		} else { // line found
+			line = src[lineStart:i]
+			numLines = 1
 		}
 
-		line := src[lineStart:i]
 		lineStart = i + 1
 
 		// Ignore empty lines
 		empty := true
+		tabs := 0
+		spaces := 0
+		h := 0
 
-		for h := 0; h < len(line); h++ {
-			if line[h] != '\t' && line[h] != ' ' {
+	loop:
+		for ; h < len(line); h++ {
+			switch line[h] {
+			case '\t':
+				tabs++
+			case ' ':
+				spaces++
+			default:
 				empty = false
-				break
+				break loop
 			}
 		}
 
@@ -68,18 +104,10 @@ func New(src string) (*CodeTree, error) {
 		}
 
 		// Indentation
-		indent := 0
+		indent := tabs + spaces/2
 
-		for indent < len(line) {
-			if line[indent] != '\t' {
-				break
-			}
-
-			indent++
-		}
-
-		if indent != 0 {
-			line = line[indent:]
+		if h != 0 {
+			line = line[h:]
 		}
 
 		if indent == block.Indent+1 {
@@ -95,7 +123,6 @@ func New(src string) (*CodeTree, error) {
 				}
 			}
 		} else if indent > block.Indent+2 {
-			lineNumber := strings.Count(src[:i], "\n") + 1
 			return nil, fmt.Errorf("Invalid indentation on line %d: %s", lineNumber, line)
 		}
 
@@ -103,9 +130,262 @@ func New(src string) (*CodeTree, error) {
 		node.Line = line
 		node.Indent = indent
 		node.Parent = block
+		node.LineNumber = lineNumber
 		lastNode = node
 		block.Children = append(block.Children, node)
 	}
 
+	return ast, nil
+}
+
+const (
+	lineStartState = iota
+	lineState
+	commentStartState
+	commentLineState
+	multilineCommentState
+	multilineCommentEndState
+)
+
+func NewFromReader(src io.Reader) (*CodeTree, error) {
+	ast := pool.Get().(*CodeTree)
+	ast.Indent = -1
+	ast.Line = ""
+	ast.Parent = nil
+	ast.LineNumber = 0
+
+	block := ast
+	lastNode := ast
+
+	var (
+		lineNumber int
+		b          byte
+		tabs       int
+		spaces     int
+		state      int
+		err        error
+	)
+
+	readBytes := 512
+
+	line := make([]byte, 0, 128)
+	buf := make([]byte, readBytes)
+
+	endLine := func() error {
+		state = lineStartState
+
+		// Ignore empty lines
+		if len(line) == 0 {
+			return nil
+		}
+
+		// Indentation
+		indent := tabs + spaces/2
+
+		if indent == block.Indent+1 {
+			// OK
+		} else if indent == block.Indent+2 {
+			block = lastNode
+		} else if indent <= block.Indent {
+			for {
+				block = block.Parent
+
+				if block.Indent == indent-1 {
+					break
+				}
+			}
+		} else if indent > block.Indent+2 {
+			return fmt.Errorf("invalid indentation on line %d: %s", lineNumber, line)
+		}
+
+		node := pool.Get().(*CodeTree)
+		node.Line = string(line)
+		node.Indent = indent
+		node.Parent = block
+		node.LineNumber = lineNumber
+		lastNode = node
+		block.Children = append(block.Children, node)
+
+		// Reset
+		tabs = 0
+		spaces = 0
+		line = line[:0]
+
+		return nil
+	}
+
+	for {
+		br, _ := src.Read(buf)
+		for i := 0; i < br; i++ {
+			b = buf[i]
+
+			// Match states first, then tokens.
+			// More verbose but, with fewer possible states than possible tokens, optimal.
+			//*
+			if b == '\r' {
+				continue
+			}
+
+			switch state {
+			case lineStartState:
+				switch b {
+				default:
+					state = lineState
+					line = append(line, b)
+				case '\t':
+					tabs++
+				case ' ':
+					spaces++
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				case '/':
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+					state = commentStartState
+					line = append(line, b)
+				}
+			case lineState:
+				switch b {
+				default:
+					line = append(line, b)
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				case '/':
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+					state = commentStartState
+					line = append(line, b)
+				}
+			case commentStartState:
+				switch b {
+				default:
+					state = lineState
+				case '/':
+					state = commentLineState
+				case '*':
+					state = multilineCommentState
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				}
+				line = append(line, b)
+			case commentLineState:
+				switch b {
+				default:
+					line = append(line, b)
+				case '\n':
+					lineNumber++
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				}
+			case multilineCommentState:
+				switch b {
+				case '*':
+					state = multilineCommentEndState
+				case '\n':
+					lineNumber++
+				}
+				line = append(line, b)
+			case multilineCommentEndState:
+				switch b {
+				case '\n':
+					lineNumber++
+					fallthrough
+				default:
+					state = multilineCommentState
+					line = append(line, b)
+				case '/':
+					line = append(line, b)
+					if err = endLine(); err != nil {
+						return nil, err
+					}
+				}
+			}
+			/*/
+			switch b {
+			case '\r':
+				continue
+			case '\t':
+				switch state {
+				case lineStartState:
+					tabs++
+				default:
+					line = append(line, b)
+				}
+			case ' ':
+				switch state {
+				case lineStartState:
+					spaces++
+				default:
+					line = append(line, b)
+				}
+			default:
+				switch state {
+				case lineStartState, commentStartState:
+					state = lineState
+				case multilineCommentEndState:
+					state = multilineCommentState
+				}
+				line = append(line, b)
+			case '\n':
+				lineNumber++
+				switch state {
+				case lineStartState, lineState, commentLineState, commentStartState:
+					if err := endLine(); err != nil {
+						return nil, err
+					}
+				case multilineCommentState:
+					line = append(line, b)
+				case multilineCommentEndState:
+					state = multilineCommentState
+					line = append(line, b)
+				}
+			case '/':
+				switch state {
+				case lineStartState, lineState:
+					if err := endLine(); err != nil {
+						return nil, err
+					}
+					state = commentStartState
+				case commentStartState:
+					state = commentLineState
+				case multilineCommentEndState:
+					line = append(line, b)
+					if err := endLine(); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				line = append(line, b)
+			case '*':
+				switch state {
+				case commentStartState:
+					state = multilineCommentState
+				case multilineCommentState:
+					state = multilineCommentEndState
+				}
+				line = append(line, b)
+			}
+			//*/
+		}
+		if br < readBytes {
+			break
+		}
+	}
+	lineNumber++
+	if err = endLine(); err != nil {
+		return nil, err
+	}
 	return ast, nil
 }

--- a/CodeTree_test.go
+++ b/CodeTree_test.go
@@ -1,8 +1,6 @@
 package codetree_test
 
 import (
-	"bytes"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -13,8 +11,8 @@ import (
 )
 
 func TestCodeTree(t *testing.T) {
-	bytes, _ := ioutil.ReadFile("test/example.txt")
-	code := string(bytes)
+	by, _ := ioutil.ReadFile("test/example.txt")
+	code := string(by)
 	tree, err := codetree.New(code)
 
 	assert.NoError(t, err)
@@ -23,11 +21,12 @@ func TestCodeTree(t *testing.T) {
 	assert.Equal(t, -1, tree.Indent)
 	assert.Equal(t, 6, len(tree.Children))
 	assert.Equal(t, "child1", tree.Children[5].Children[0].Line)
+	assert.Equal(t, "日本語", tree.Children[1].Children[0].Line)
 }
 
 func TestBadIndentation(t *testing.T) {
-	bytes, _ := ioutil.ReadFile("test/bad-indentation.txt")
-	code := string(bytes)
+	by, _ := ioutil.ReadFile("test/bad-indentation.txt")
+	code := string(by)
 	tree, err := codetree.New(code)
 
 	assert.Nil(t, tree)
@@ -35,82 +34,63 @@ func TestBadIndentation(t *testing.T) {
 }
 
 func BenchmarkCodeTree(b *testing.B) {
-	bytes, _ := ioutil.ReadFile("test/example.txt")
-	code := string(bytes)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		tree, _ := codetree.New(code)
-		tree.Close()
-	}
-}
-
-func TestCodeTreeFromReader(t *testing.T) {
-	file, _ := os.Open("test/example.txt")
-	tree, err := codetree.NewFromReader(file)
-
-	assert.NoError(t, err)
-	defer tree.Close()
-
-	assert.Equal(t, -1, tree.Indent)
-	assert.Equal(t, 6, len(tree.Children))
-	assert.Equal(t, "child1", tree.Children[5].Children[0].Line)
-}
-
-func TestCodeTreeCompare(t *testing.T) {
-	bytes, _ := ioutil.ReadFile("test/example.txt")
-	code := string(bytes)
-	tree, err := codetree.New(code)
-	assert.NoError(t, err)
-	defer tree.Close()
-
-	file, _ := os.Open("test/example.txt")
-	defer file.Close()
-	rTree, err := codetree.NewFromReader(file)
-	assert.NoError(t, err)
-	defer rTree.Close()
-
-	assert.Equal(t, tree, rTree)
-}
-
-func BenchmarkCodeTreeFromReader(b *testing.B) {
 	by, _ := ioutil.ReadFile("test/example.txt")
-	reader := bytes.NewReader(by)
+	code := string(by)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		reader.Seek(0, io.SeekStart)
-		tree, _ := codetree.NewFromReader(reader)
-		tree.Close()
-	}
-}
-
-func BenchmarkCodeTreeOpen(b *testing.B) {
-
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		by, _ := ioutil.ReadFile("test/example.txt")
-		code := string(by)
 		tree, _ := codetree.New(code)
 		tree.Close()
 	}
 }
 
-func BenchmarkCodeTreeFromReaderOpen(b *testing.B) {
+func TestComments(t *testing.T) {
+	reader, _ := os.Open("test/comments.txt")
+	tree, err := codetree.FromReader(reader)
+	defer reader.Close()
+	assert.Nil(t, err)
+	assert.Equal(t, codetree.RootType, tree.Type)
+	assert.Equal(t, 9, len(tree.Children))
+	assert.Equal(t, codetree.CommentType, tree.Children[6].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[0].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Children[2].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[2].Children[0].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Children[3].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[3].Children[0].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Children[4].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[4].Children[0].Type)
+	assert.Equal(t, 5, len(tree.Children[7].Children))
+	assert.Equal(t, codetree.CommentType, tree.Children[8].Type)
+}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		file, _ := os.Open("test/example.txt")
-		tree, _ := codetree.NewFromReader(file)
-		tree.Close()
-		file.Close()
+func TestFromFilelist(t *testing.T) {
+	list := []string{"test/example.txt", "test/comments.txt"}
+	tree, err := codetree.FromFilelist(list)
+	assert.Nil(t, err)
+	assert.Equal(t, codetree.RootType, tree.Type)
+	for i, filename := range list {
+		assert.Equal(t, filename, tree.Children[i].Filename)
+		assert.Equal(t, codetree.RootType, tree.Children[i].Type)
+		assert.Equal(t, 23, tree.Children[i].Children[4].LineNumber)
+		assert.Equal(t, 25, tree.Children[i].Children[4].Children[1].LineNumber)
+		assert.Equal(t, 28, tree.Children[i].Children[4].Children[2].Children[1].LineNumber)
 	}
+	assert.Equal(t, 34, tree.Children[1].Children[6].LineNumber)
+	assert.Equal(t, 35, tree.Children[1].Children[7].LineNumber)
+	assert.Equal(t, 36, tree.Children[1].Children[7].Children[0].LineNumber)
+	assert.Equal(t, 37, tree.Children[1].Children[7].Children[1].LineNumber)
+
+	assert.Equal(t, 38, tree.Children[1].Children[7].Children[2].LineNumber)
+	assert.Equal(t, 38, tree.Children[1].Children[7].Children[2].Children[0].LineNumber)
+
+	assert.Equal(t, 39, tree.Children[1].Children[7].Children[3].LineNumber)
+	assert.Equal(t, 39, tree.Children[1].Children[7].Children[3].Children[0].LineNumber)
+
+	assert.Equal(t, 40, tree.Children[1].Children[7].Children[4].LineNumber)
+	assert.Equal(t, 40, tree.Children[1].Children[7].Children[4].Children[0].LineNumber)
+
+	assert.Equal(t, 47, tree.Children[1].Children[8].LineNumber)
 }

--- a/CodeTree_test.go
+++ b/CodeTree_test.go
@@ -2,6 +2,7 @@ package codetree_test
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,8 +40,8 @@ func TestBadIndentation(t *testing.T) {
 }
 
 func BenchmarkCodeTree(b *testing.B) {
-	bytes, _ := ioutil.ReadFile("example.txt")
-	code := string(bytes)
+	by, _ := ioutil.ReadFile("testdata/example.txt")
+	code := string(by)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -54,4 +55,53 @@ func BenchmarkCodeTree(b *testing.B) {
 
 		tree.Close()
 	}
+}
+
+func TestComments(t *testing.T) {
+	reader, _ := os.Open("testdata/comments.txt")
+	tree, err := codetree.FromReader(reader)
+	defer reader.Close()
+	assert.Nil(t, err)
+	assert.Equal(t, codetree.RootType, tree.Type)
+	assert.Equal(t, 9, len(tree.Children))
+	assert.Equal(t, codetree.CommentType, tree.Children[6].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[0].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Children[2].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[2].Children[0].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Children[3].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[3].Children[0].Type)
+	assert.Equal(t, codetree.LineType, tree.Children[7].Children[4].Type)
+	assert.Equal(t, codetree.CommentType, tree.Children[7].Children[4].Children[0].Type)
+	assert.Equal(t, 5, len(tree.Children[7].Children))
+	assert.Equal(t, codetree.CommentType, tree.Children[8].Type)
+}
+
+func TestFromFilelist(t *testing.T) {
+	list := []string{"testdata/example.txt", "testdata/comments.txt"}
+	tree, err := codetree.FromFilelist(list)
+	assert.Nil(t, err)
+	assert.Equal(t, codetree.RootType, tree.Type)
+	for i, filename := range list {
+		assert.Equal(t, filename, tree.Children[i].Filename)
+		assert.Equal(t, codetree.RootType, tree.Children[i].Type)
+		assert.Equal(t, 23, tree.Children[i].Children[4].LineNumber)
+		assert.Equal(t, 25, tree.Children[i].Children[4].Children[1].LineNumber)
+		assert.Equal(t, 28, tree.Children[i].Children[4].Children[2].Children[1].LineNumber)
+	}
+	assert.Equal(t, 34, tree.Children[1].Children[6].LineNumber)
+	assert.Equal(t, 35, tree.Children[1].Children[7].LineNumber)
+	assert.Equal(t, 36, tree.Children[1].Children[7].Children[0].LineNumber)
+	assert.Equal(t, 37, tree.Children[1].Children[7].Children[1].LineNumber)
+
+	assert.Equal(t, 38, tree.Children[1].Children[7].Children[2].LineNumber)
+	assert.Equal(t, 38, tree.Children[1].Children[7].Children[2].Children[0].LineNumber)
+
+	assert.Equal(t, 39, tree.Children[1].Children[7].Children[3].LineNumber)
+	assert.Equal(t, 39, tree.Children[1].Children[7].Children[3].Children[0].LineNumber)
+
+	assert.Equal(t, 40, tree.Children[1].Children[7].Children[4].LineNumber)
+	assert.Equal(t, 40, tree.Children[1].Children[7].Children[4].Children[0].LineNumber)
+
+	assert.Equal(t, 47, tree.Children[1].Children[8].LineNumber)
 }

--- a/CodeTree_test.go
+++ b/CodeTree_test.go
@@ -1,7 +1,10 @@
 package codetree_test
 
 import (
+	"bytes"
+	"io"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +35,7 @@ func TestBadIndentation(t *testing.T) {
 }
 
 func BenchmarkCodeTree(b *testing.B) {
-	bytes, _ := ioutil.ReadFile("example.txt")
+	bytes, _ := ioutil.ReadFile("test/example.txt")
 	code := string(bytes)
 
 	b.ReportAllocs()
@@ -41,5 +44,73 @@ func BenchmarkCodeTree(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tree, _ := codetree.New(code)
 		tree.Close()
+	}
+}
+
+func TestCodeTreeFromReader(t *testing.T) {
+	file, _ := os.Open("test/example.txt")
+	tree, err := codetree.NewFromReader(file)
+
+	assert.NoError(t, err)
+	defer tree.Close()
+
+	assert.Equal(t, -1, tree.Indent)
+	assert.Equal(t, 6, len(tree.Children))
+	assert.Equal(t, "child1", tree.Children[5].Children[0].Line)
+}
+
+func TestCodeTreeCompare(t *testing.T) {
+	bytes, _ := ioutil.ReadFile("test/example.txt")
+	code := string(bytes)
+	tree, err := codetree.New(code)
+	assert.NoError(t, err)
+	defer tree.Close()
+
+	file, _ := os.Open("test/example.txt")
+	defer file.Close()
+	rTree, err := codetree.NewFromReader(file)
+	assert.NoError(t, err)
+	defer rTree.Close()
+
+	assert.Equal(t, tree, rTree)
+}
+
+func BenchmarkCodeTreeFromReader(b *testing.B) {
+	by, _ := ioutil.ReadFile("test/example.txt")
+	reader := bytes.NewReader(by)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		reader.Seek(0, io.SeekStart)
+		tree, _ := codetree.NewFromReader(reader)
+		tree.Close()
+	}
+}
+
+func BenchmarkCodeTreeOpen(b *testing.B) {
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		by, _ := ioutil.ReadFile("test/example.txt")
+		code := string(by)
+		tree, _ := codetree.New(code)
+		tree.Close()
+	}
+}
+
+func BenchmarkCodeTreeFromReaderOpen(b *testing.B) {
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		file, _ := os.Open("test/example.txt")
+		tree, _ := codetree.NewFromReader(file)
+		tree.Close()
+		file.Close()
 	}
 }

--- a/test/comments.txt
+++ b/test/comments.txt
@@ -30,3 +30,19 @@ parent5
 
 parent6
 	child1
+
+// Parent Seven
+parent7
+	// A child
+	child1
+	child2 // Another child
+  child3 /* Another child */
+  child4 /*
+	child5
+	child6
+	/*
+	child7
+	*/
+
+/*parent8
+	child1*/

--- a/testdata/comments.txt
+++ b/testdata/comments.txt
@@ -30,3 +30,19 @@ parent5
 
 parent6
 	child1
+
+// Parent Seven
+parent7
+	// A child
+	child1
+	child2 // Another child
+  child3 /* Another child */
+  child4 /*
+	child5
+	child6
+	/*
+	child7
+	*/
+
+/*parent8
+	child1*/


### PR DESCRIPTION
Hello,

I've incorporated comment parsing, both single and multi-line directly into the CodeTree parser, while this does reduce the agnosticism of the CodeTree format a bit I believed it was the optimal place to do it. I'm also allowing multi-file input and recording the type, line number and filename of each node with a view to generating CSS sourcemaps from Scarlet.

Possibly contentious: I've changed the main parsing loop to a finite(ish) state machine reading a byte at a time from a Reader. I think using a Reader is more idiomatic, versatile and, assuming the file is re-read every time which in the wild it would be, optimal as there's less copying going on. [See commit for benchmarks.](https://github.com/facefunk/codetree/commit/dc360a9835e9f8b911e380e55dc1eb4067d84607) However this may be undesirable if it begins to carry the project away from an ideal of beautiful simplicity that you've certainly achieved, if so I understand completely.